### PR TITLE
CMake: enable SAFESEH feature for MASM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,12 +71,14 @@ elseif(WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GS- /Zc:wchar_t /Zc:forScope /DUSE_WINTHREAD")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D_CRT_SECURE_NO_DEPRECATE /D_WIN32_WINNT=0x0600 /volatile:iso")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4267 /wd4800 /wd4146 /wd4244 /wd4018")
+  # Enable SAFESEH feature for assembly
+  set(CMAKE_ASM_MASM_FLAGS "${CMAKE_ASM_MASM_FLAGS} /safeseh")
 
   if (CMAKE_SIZEOF_VOID_P EQUAL 8)
     list(APPEND tbb_src src/tbb/intel64-masm/atomic_support.asm
       src/tbb/intel64-masm/itsx.asm src/tbb/intel64-masm/intel64_misc.asm)
     list(APPEND tbbmalloc_src src/tbb/intel64-masm/atomic_support.asm)
-    set(CMAKE_ASM_MASM_FLAGS "/DEM64T=1")
+    set(CMAKE_ASM_MASM_FLAGS "${CMAKE_ASM_MASM_FLAGS}/DEM64T=1")
     set(ARCH_PREFIX "win64")
   else()
     list(APPEND tbb_src src/tbb/ia32-masm/atomic_support.asm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,19 +71,19 @@ elseif(WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GS- /Zc:wchar_t /Zc:forScope /DUSE_WINTHREAD")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D_CRT_SECURE_NO_DEPRECATE /D_WIN32_WINNT=0x0600 /volatile:iso")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4267 /wd4800 /wd4146 /wd4244 /wd4018")
-  # Enable SAFESEH feature for assembly
-  set(CMAKE_ASM_MASM_FLAGS "${CMAKE_ASM_MASM_FLAGS} /safeseh")
 
   if (CMAKE_SIZEOF_VOID_P EQUAL 8)
     list(APPEND tbb_src src/tbb/intel64-masm/atomic_support.asm
       src/tbb/intel64-masm/itsx.asm src/tbb/intel64-masm/intel64_misc.asm)
     list(APPEND tbbmalloc_src src/tbb/intel64-masm/atomic_support.asm)
-    set(CMAKE_ASM_MASM_FLAGS "${CMAKE_ASM_MASM_FLAGS}/DEM64T=1")
+    set(CMAKE_ASM_MASM_FLAGS "${CMAKE_ASM_MASM_FLAGS} /DEM64T=1")
     set(ARCH_PREFIX "win64")
   else()
     list(APPEND tbb_src src/tbb/ia32-masm/atomic_support.asm
       src/tbb/ia32-masm/itsx.asm src/tbb/ia32-masm/lock_byte.asm)
     list(APPEND tbbmalloc_src src/tbb/ia32-masm/atomic_support.asm)
+    # Enable SAFESEH feature for assembly (x86 builds only).
+    set(CMAKE_ASM_MASM_FLAGS "${CMAKE_ASM_MASM_FLAGS} /safeseh")
     set(ARCH_PREFIX "win32")
   endif()
   set(ENABLE_RTTI "/EHsc /GR ")


### PR DESCRIPTION
This option is disabled by default on calls to MASM (the Microsoft Assembler). The assembled files (e.g. `atomic_support.obj`) will lack the SAFESEH feature and prevent linking on Windows (Visual Studio 2015).

---

(I thought I had created this PR before but there is no trace of it, apologies if it was already received).