### PR TITLE
Fix GCC 6.X, dead store elimination (DSE) optimises away memset in al…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,7 @@ endif()
 
 ##-------
 
-if (CMAKE_COMPILER_IS_GNUCC AND UNIX AND NOT APPLE)
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND UNIX AND NOT APPLE)
    check_cxx_compiler_flag ("-flifetime-dse=1" SUPPORTS_FLIFETIME)
    if (SUPPORTS_FLIFETIME)
      add_definitions(-flifetime-dse=1)
@@ -225,7 +225,7 @@ if (TBB_BUILD_SHARED)
 endif()
 
 
-if(CMAKE_COMPILER_IS_GNUCC)
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   # Quench a warning on GCC
   set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/tbb/governor.cpp COMPILE_FLAGS "-Wno-missing-field-initializers ")
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")


### PR DESCRIPTION
In my Fedora 25 box with cmake version 3.6.2 and gcc (GCC) 6.2.1 20160916.

It took me some time to figure it out why tbb::parallel_for crash in my box. 

Although CMakeLists.txt contains fix to disable GCC6 optimization, the variable "CMAKE_COMPILER_IS_GNUCC" is not working. 
