### PR TITLE
C make cpp11 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,24 @@
 cmake_minimum_required (VERSION 2.8.12 FATAL_ERROR)
+foreach(p
+    CMP0048  ##NEW project() behavior for setting VERSION variable
+    CMP0025 # CMake 3.0 AppleClang vs. regular Clang
+    CMP0042 # CMake 3.0 ``MACOSX_RPATH`` is enabled by default.
+    CMP0054 # CMake 3.1 Only interpret ``if()`` arguments as variables or keywords when unquoted.
+    CMP0056 # CMake 3.2 Honor link flags in ``try_compile()`` source-file signature.
+    CMP0058 # CMake 3.3 Ninja requires custom command byproducts to be explicit.
+    CMP0063 # CMake 3.3.2 Honor visibility properties for all target types
+    )
+  if(POLICY ${p})
+    cmake_policy(SET ${p} NEW)
+  endif()
+endforeach()
+if (POLICY CMP0023)
+  cmake_policy(SET CMP0023 OLD) #Plain and keyword target_link_libraries signatures cannot be mixed.
+endif()
+
 project (tbb CXX)
 
 include (CheckCXXCompilerFlag)
-
-if(POLICY CMP0058)
-  cmake_policy(SET CMP0058 NEW)
-endif()
-
-if (POLICY CMP0023)
-  cmake_policy(SET CMP0023 OLD)
-endif()
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting build type to 'Release' as none was specified.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,59 @@
-cmake_minimum_required (VERSION 2.8.12 FATAL_ERROR)
+#
+# CMake buld configuration for tbb
+#
+if(DEFINED CMAKE_CXX_STANDARD AND (NOT ${CMAKE_CXX_STANDARD} EQUAL "98" ))
+  cmake_minimum_required(VERSION 3.2.0 FATAL_ERROR) ## 3.2.0 needed for AppleClang CXX11 detection
+else()
+  cmake_minimum_required (VERSION 2.8.12 FATAL_ERROR)
+endif()
+
+if("${CMAKE_VERSION}" VERSION_LESS 3.2.0)
+  message(STATUS "NOTE: CMake version 3.2.0 or greater will provide more complete build support features.")
+endif()
+
+#
+# enable language features that may affect other settings
+# including the ability to try_compile when searching for C++11
+enable_language(CXX)
+#
+# Try to force compilers support CXX 11 by default
+#
+# NOTE: Linking libraries compiled with different standards conformance
+#       may result in errors at runtime.  This is particularly true
+#       on some mac build environments where the
+#       standard template library is defaulted to versions with
+#       different ABI based on the the CXX standard choosen.
+#       It is recommended that all applications (i.e. downstream
+#       applications that depend on this build of tbb) use
+#       the same compiler standard conformance as when tbb
+#       as built.
+#
+#
+#
+include (CheckCXXCompilerFlag)
+if("${CMAKE_VERSION}" VERSION_LESS 3.2.0) #Fallback for old versions of cmake
+  if(NOT CMAKE_CXX_STANDARD OR "${CMAKE_CXX_STANDARD}" LESS "98")
+    ## Use unreliable method for propagating and configuring for
+    #  cmake instrospection with c++11 features
+    check_cxx_compiler_flag ("-std=c++11" SUPPORTS_STDCXX11)
+    if (SUPPORTS_STDCXX11)
+      set (CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+      set(CMAKE_CXX_STANDARD "11") ## Default to cmake standard version 11 if not previously set
+    else()
+      set(CMAKE_CXX_STANDARD "98") ## Default to cmake standard version 98 if -std=c++11 not supported
+    endif ()
+   endif()
+else()
+  ## In recent versions of cmake, it is recommended
+  ## to use CMAKE_CXX_STANDARD, which will allow for
+  ## 98,11,or 14 as options currently, and provides
+  ## extensive compiler specific feature support.
+  if(NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD "11") ## Default to cmake standard version 11 if not previously set
+  endif()
+endif()
+message(STATUS "Building with CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}")
+
 foreach(p
     CMP0048  ##NEW project() behavior for setting VERSION variable
     CMP0025 # CMake 3.0 AppleClang vs. regular Clang
@@ -18,7 +73,6 @@ endif()
 
 project (tbb CXX)
 
-include (CheckCXXCompilerFlag)
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting build type to 'Release' as none was specified.")
@@ -78,11 +132,6 @@ endif()
 
 if (UNIX)
   add_definitions (-DUSE_PTHREAD)
-
-  check_cxx_compiler_flag ("-std=c++11" SUPPORTS_STDCXX11)
-  if (SUPPORTS_STDCXX11)
-    set (CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
-  endif ()
 
   check_cxx_compiler_flag ("-mrtm" SUPPORTS_MRTM)
   if (SUPPORTS_MRTM)


### PR DESCRIPTION
This builds upon #34 to also take advantage of newer CMake capabilities in Cmake 3.2 and greater for C++ 11 compiler usage.