### PR TITLE
Fix has_trivial_copy_constructor issue

### DIFF
--- a/include/tbb/pipeline.h
+++ b/include/tbb/pipeline.h
@@ -325,7 +325,7 @@ template<typename T> struct tbb_large_object {enum { value = sizeof(T) > sizeof(
 #if   __TBB_CPP11_TYPE_PROPERTIES_PRESENT
 template<typename T> struct tbb_trivially_copyable { enum { value = std::is_trivially_copyable<T>::value }; };
 #elif __TBB_TR1_TYPE_PROPERTIES_IN_STD_PRESENT
-template<typename T> struct tbb_trivially_copyable { enum { value = std::has_trivial_copy_constructor<T>::value }; };
+template<typename T> struct tbb_trivially_copyable { enum { value = std::is_trivially_copy_constructible<T>::value }; };
 #else
 // Explicitly list the types we wish to be placed as-is in the pipeline input_buffers.
 template<typename T> struct tbb_trivially_copyable { enum { value = false }; };


### PR DESCRIPTION
has_trivial_copy_constructor is not a member of ‘std’, replaced by is_trivially_copy_constructible.