### PR TITLE
Python irml compile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     - os: linux
       compiler: g++
       script:
-        - cmake -DCMAKE_INSTALL_PREFIX=~/.local .
+        - cmake -DTBB_BUILD_PYTHON=ON -DCMAKE_INSTALL_PREFIX=~/.local .
         - make install -j2
         - ctest -j2 --output-on-failure --timeout 500
       addons:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -631,7 +631,7 @@ if (TBB_BUILD_PYTHON)
 
     if(UNIX AND NOT APPLE)
       add_library(irml SHARED python/rml/ipc_server.cpp python/rml/ipc_utils.cpp src/tbb/cache_aligned_allocator.cpp src/tbb/dynamic_link.cpp src/tbb/tbb_misc_ex.cpp src/tbb/tbb_misc.cpp)
-      target_compile_definitions(irml PRIVATE DO_ITT_NOTIFY=0)
+      target_compile_definitions(irml PRIVATE DO_ITT_NOTIFY=0 USE_PTHREAD=1)
       target_link_libraries(irml PRIVATE tbb)
       set_target_properties(irml PROPERTIES VERSION 1)
       install(TARGETS irml DESTINATION ${TBB_INSTALL_LIBRARY_DIR})


### PR DESCRIPTION
I've found that irml will not compile on linux since https://github.com/wjakob/tbb/blob/master/src/rml/server/thread_monitor.h#L30 gets included. 
I would also consider switching to `find_package(Python3)` since the python 2 to is EOL and with `find_package(PythonInterp)` it's harder to get python 3 if your system still has python 2 installed. 