### PR TITLE
Add initial clang mingw support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,9 +215,13 @@ else()
 endif()
 
 if (MINGW)
-  set (ARCH_PREFIX "${ARCH_PREFIX}-gcc")
-  # there's no win32-gcc-tbb-export.def, use lin32-tbb-export.def
-  execute_process (COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/src/tbb/lin32-tbb-export.def ${CMAKE_CURRENT_SOURCE_DIR}/src/tbb/win32-gcc-tbb-export.def)
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set (ARCH_PREFIX "${ARCH_PREFIX}-clang")
+  else()
+    set (ARCH_PREFIX "${ARCH_PREFIX}-gcc")
+    # there's no win32-gcc-tbb-export.def, use lin32-tbb-export.def
+    execute_process (COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/src/tbb/lin32-tbb-export.def ${CMAKE_CURRENT_SOURCE_DIR}/src/tbb/win32-gcc-tbb-export.def)
+  endif()
 endif()
 
 if (MSVC)
@@ -279,7 +283,8 @@ if (TBB_BUILD_SHARED)
     set_property(TARGET tbb APPEND PROPERTY LINK_FLAGS "-Wl,-exported_symbols_list,\"${CMAKE_CURRENT_BINARY_DIR}/tbb.def\"")
   elseif (MSVC)
     set_property(TARGET tbb APPEND PROPERTY LINK_FLAGS "/DEF:\"${CMAKE_CURRENT_BINARY_DIR}/tbb.def\"")
-  else ()
+  elseif (MINGW AND (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")) # do nothing
+  else()
     set_property(TARGET tbb APPEND PROPERTY LINK_FLAGS "-Wl,-version-script,\"${CMAKE_CURRENT_BINARY_DIR}/tbb.def\"")
   endif()
 
@@ -335,6 +340,7 @@ if(TBB_BUILD_TBBMALLOC)
       set_property(TARGET tbbmalloc APPEND PROPERTY LINK_FLAGS "-Wl,-exported_symbols_list,\"${CMAKE_CURRENT_BINARY_DIR}/tbbmalloc.def\"")
     elseif (MSVC)
       set_property(TARGET tbbmalloc APPEND PROPERTY LINK_FLAGS "/DEF:\"${CMAKE_CURRENT_BINARY_DIR}/tbbmalloc.def\"")
+    elseif (MINGW AND (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")) # do nothing
     else ()
       set_property(TARGET tbbmalloc APPEND PROPERTY LINK_FLAGS "-Wl,-version-script,\"${CMAKE_CURRENT_BINARY_DIR}/tbbmalloc.def\"")
     endif()

--- a/src/tbb/win32-clang-tbb-export.def
+++ b/src/tbb/win32-clang-tbb-export.def
@@ -1,0 +1,20 @@
+; Copyright (c) 2005-2020 Intel Corporation
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+EXPORTS
+
+#define __TBB_SYMBOL( sym ) sym
+#include "lin32-tbb-export.lst"
+
+

--- a/src/tbb/win64-clang-tbb-export.def
+++ b/src/tbb/win64-clang-tbb-export.def
@@ -1,0 +1,22 @@
+; Copyright (c) 2005-2020 Intel Corporation
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+; This file is organized with a section for each .cpp file.
+; Each of these sections is in alphabetical order.
+
+EXPORTS
+
+#define __TBB_SYMBOL( sym ) sym
+#include "win64-gcc-tbb-export.lst"
+

--- a/src/tbbmalloc/win32-clang-tbbmalloc-export.def
+++ b/src/tbbmalloc/win32-clang-tbbmalloc-export.def
@@ -1,0 +1,45 @@
+; Copyright (c) 2005-2020 Intel Corporation
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+EXPORTS
+
+; frontend.cpp
+scalable_calloc
+scalable_free
+scalable_malloc
+scalable_realloc
+scalable_posix_memalign
+scalable_aligned_malloc
+scalable_aligned_realloc
+scalable_aligned_free
+scalable_msize
+scalable_allocation_mode
+scalable_allocation_command
+__TBB_malloc_safer_free
+__TBB_malloc_safer_realloc
+__TBB_malloc_safer_msize
+__TBB_malloc_safer_aligned_msize
+__TBB_malloc_safer_aligned_realloc
+_ZN3rml10pool_resetEPNS_10MemoryPoolE
+_ZN3rml11pool_createEiPKNS_13MemPoolPolicyE
+_ZN3rml14pool_create_v1EiPKNS_13MemPoolPolicyEPPNS_10MemoryPoolE
+_ZN3rml11pool_mallocEPNS_10MemoryPoolEj
+_ZN3rml12pool_destroyEPNS_10MemoryPoolE
+_ZN3rml9pool_freeEPNS_10MemoryPoolEPv
+_ZN3rml12pool_reallocEPNS_10MemoryPoolEPvj
+_ZN3rml20pool_aligned_reallocEPNS_10MemoryPoolEPvjj
+_ZN3rml19pool_aligned_mallocEPNS_10MemoryPoolEjj
+_ZN3rml13pool_identifyEPv
+_ZN3rml10pool_msizeEPNS_10MemoryPoolEPv
+

--- a/src/tbbmalloc/win64-clang-tbbmalloc-export.def
+++ b/src/tbbmalloc/win64-clang-tbbmalloc-export.def
@@ -1,0 +1,46 @@
+; Copyright (c) 2005-2020 Intel Corporation
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+EXPORTS
+
+; frontend.cpp
+scalable_calloc
+scalable_free
+scalable_malloc
+scalable_realloc
+scalable_posix_memalign
+scalable_aligned_malloc
+scalable_aligned_realloc
+scalable_aligned_free
+scalable_msize
+scalable_allocation_mode
+scalable_allocation_command
+__TBB_malloc_safer_free
+__TBB_malloc_safer_realloc
+__TBB_malloc_safer_msize
+__TBB_malloc_safer_aligned_msize
+__TBB_malloc_safer_aligned_realloc
+; memory pool stuff
+_ZN3rml10pool_resetEPNS_10MemoryPoolE
+_ZN3rml11pool_createExPKNS_13MemPoolPolicyE
+_ZN3rml14pool_create_v1ExPKNS_13MemPoolPolicyEPPNS_10MemoryPoolE
+_ZN3rml11pool_mallocEPNS_10MemoryPoolEy
+_ZN3rml12pool_destroyEPNS_10MemoryPoolE
+_ZN3rml9pool_freeEPNS_10MemoryPoolEPv
+_ZN3rml12pool_reallocEPNS_10MemoryPolEPvy
+_ZN3rml20pool_aligned_reallocEPNS_10MemoryPoolEPvyy
+_ZN3rml19pool_aligned_mallocEPNS_10MemoryPoolEyy
+_ZN3rml13pool_identifyEPv
+_ZN3rml10pool_msizeEPNS_10MemoryPoolEPv
+


### PR DESCRIPTION
I hope Intel won't do a significant API change in the near future, doing this was quite tedious.
Luckily it's just some copy-pasting between the MSVC and GCC files, if they add a new function or something else then it isn't that bad.

Tested with llvm-mingw (clang-cl is still a bit unhappy with command-line switches starting with /)