### PR TITLE
Allow at runtime malloc replacement using LoadLibary()

### DIFF
--- a/src/tbbmalloc/proxy.cpp
+++ b/src/tbbmalloc/proxy.cpp
@@ -788,7 +788,7 @@ void doMallocReplacement()
 extern "C" BOOL WINAPI DllMain( HINSTANCE hInst, DWORD callReason, LPVOID reserved )
 {
 
-    if ( callReason==DLL_PROCESS_ATTACH && reserved && hInst ) {
+    if ( callReason==DLL_PROCESS_ATTACH && hInst ) {
 #if !__TBB_WIN8UI_SUPPORT
         if (!tbb::internal::GetBoolEnvironmentVariable("TBB_MALLOC_DISABLE_REPLACEMENT"))
         {


### PR DESCRIPTION

When a .dll is loaded using the LoadLibary then the "reserved parameter " is NULL in the DllMain() function. This makes it impossible to dynamicly load the malloc_proxy dynamicly at runtime becasue the reserved parameter is checked to be not null.  So I removed the needles condition on that variable so that the doMallocReplacement() can be called. This allows programmers to create applications that can "optionally" use the tbb_malloc replacement without having to re-link the application.